### PR TITLE
Tweak bounds on text and blaze-builder.

### DIFF
--- a/snooze.cabal
+++ b/snooze.cabal
@@ -20,7 +20,7 @@ library
                      , http-client                     == 0.4.*
                      , http-types                      == 0.8.*
                      , p
-                     , text                            == 1.1.*
+                     , text                            >= 1.1       && < 1.3
                      , template-haskell
                      , transformers                    == 0.4.*
 


### PR DESCRIPTION
Not sure which way to go here, given these are largely compatible and we were globally limited by the lower of the two bounds anyway, I have just made them wider. The alternative would be to thread the needle through all the common dependencies, but I am not sure how tractable that is because it means the bounds of these lower level projects are controlled by the things that depend on them which is just backwards - so I am considering this, the lesser of two evils at the moment.
