### PR TITLE
Fix flakey withServer due to connection refused

### DIFF
--- a/snooze.cabal
+++ b/snooze.cabal
@@ -79,11 +79,13 @@ test-suite test-io
                      , aeson
                      , disorder-core
                      , disorder-corpus
+                     , network
                      , p
                      , scotty                          >= 0.8        && < 0.10
                      , QuickCheck                      == 2.7.*
                      , quickcheck-instances            == 0.3.*
                      , random
+                     , retry
                      , snooze
                      , text
                      , wai

--- a/test/Test/Snooze/Server.hs
+++ b/test/Test/Snooze/Server.hs
@@ -4,9 +4,11 @@ module Test.Snooze.Server where
 
 import           Control.Concurrent
 import           Control.Exception
+import           Control.Retry
 
 import           Data.Text as T
 
+import           Network
 import           Network.Wai (rawPathInfo)
 
 import           P
@@ -24,15 +26,16 @@ withServer app f = do
   -- FIX Find an open port rather than failing randomly
   port <- randomRIO (10100, 65534)
   let url' = "http://localhost:" <> (T.pack $ show port) <> "/"
+  -- Check that we can connect first to avoid flakey "connection refused"
+  let connect' = bracket (connectTo "localhost" $ PortNumber (fromInteger $ toInteger port)) hClose pure
   bracket
     (forkIO . scotty port $ app)
     killThread
-    (const $ f url')
-  
+    (const $ (recoverAll (limitRetries 5) connect') >> f url')
+
 withServer' :: Path -> ScottyM () -> (Url -> IO a) -> IO a
 withServer' p s a =
   withServer s $ \b -> maybe (fail $ "Bad URL" <> T.unpack b) pure (url b p) >>= a
-
 
 -- Unfortunately the "Web.Scotty.Route" 'literal' match doesn't always match
 pathRoutePattern :: Path -> RoutePattern


### PR DESCRIPTION
/cc @tmcgilchrist @michaelneale As discussed. I _always_ see this "connection refused" locally (at least in ghci), which isn't the quite same thing as the port being taken.
