### PR TITLE
Use streaming-commons to find open port

### DIFF
--- a/snooze.cabal
+++ b/snooze.cabal
@@ -89,9 +89,9 @@ test-suite test-io
                      , network
                      , p
                      , scotty                          >= 0.8        && < 0.10
+                     , streaming-commons               == 0.1.12.*
                      , QuickCheck                      == 2.7.*
                      , quickcheck-instances            == 0.3.*
-                     , random
                      , retry
                      , snooze
                      , text

--- a/test/Test/Snooze/Server.hs
+++ b/test/Test/Snooze/Server.hs
@@ -6,6 +6,7 @@ import           Control.Concurrent
 import           Control.Exception
 import           Control.Retry
 
+import           Data.Streaming.Network
 import           Data.Text as T
 
 import           Network
@@ -16,15 +17,13 @@ import           P
 import           Snooze.Url
 
 import           System.IO
-import           System.Random (randomRIO)
 
 import           Web.Scotty
 
 
 withServer :: ScottyM () -> (Text -> IO a) -> IO a
 withServer app f = do
-  -- FIX Find an open port rather than failing randomly
-  port <- randomRIO (10100, 65534)
+  port <- getUnassignedPort
   let url' = "http://localhost:" <> (T.pack $ show port) <> "/"
   -- Check that we can connect first to avoid flakey "connection refused"
   let connect' = bracket (connectTo "localhost" $ PortNumber (fromInteger $ toInteger port)) hClose pure

--- a/test/snooze-test.cabal
+++ b/test/snooze-test.cabal
@@ -11,11 +11,11 @@ library
                      , p
                      , QuickCheck
                      , quickcheck-instances
-                     , random
                      , scotty
                      , snooze
                      , text
                      , wai
+                     , streaming-commons          == 0.1.12.*
                      , twine                      == 0.0.1
                      , retry                      == 0.6.*
                      , network                    == 2.6.*


### PR DESCRIPTION
@fractalcat Actually I found this by accident (it's what scotty -> warp uses for binding). Technically we should actually do the bind and pass the socket to scotty, but this was easier and should be find.
