### PR TITLE
Really basic data-types for snooze improvements.

### DIFF
--- a/mafia
+++ b/mafia
@@ -9,24 +9,47 @@ fetch_latest () {
   fi
 }
 
+latest_version () {
+  git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+}
+
+local_version () {
+  awk '/^# Version: / { print $3; exit 0; }' $0
+}
+
 run_upgrade () {
+  MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
+
+  clean_up () {
+    rm -f "$MAFIA_TEMP"
+  }
+
+  trap clean_up EXIT
+
+  MAFIA_CUR="$0"
+
+  if [ -L "$MAFIA_CUR" ]; then
+    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
+    exit 1
+  fi
+
   echo "Checking for a new version of mafia ..."
-  fetch_latest > /tmp/mafia
+  fetch_latest > $MAFIA_TEMP
 
-  COMMIT_VERSION=$(git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1)
-  echo "# Version: $COMMIT_VERSION" >> /tmp/mafia
+  LATEST_VERSION=$(latest_version)
+  echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
 
-  if ! cmp ./mafia /tmp/mafia >/dev/null 2>&1; then
+  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
+    mv $MAFIA_TEMP $MAFIA_CUR
+    chmod +x $MAFIA_CUR
     echo "New version found and upgraded. You can now commit it to your git repo."
-    mv /tmp/mafia ./mafia
-    chmod +x ./mafia
   else
-    echo "You have latest mafia script"
+    echo "You have latest mafia."
   fi
 }
 
 exec_mafia () {
-  MAFIA_VERSION=$(awk '/^# Version: / { print $3; exit 0; }' $0)
+  MAFIA_VERSION=$(local_version)
 
   if [ "x$MAFIA_VERSION" = "x" ]; then
     # If we can't find the mafia version, then we need to upgrade the script.
@@ -41,7 +64,9 @@ exec_mafia () {
       # terminates. Unfortunately `mktemp` doesn't behave the same on
       # Linux and OS/X so we need to try two different approaches.
       MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
+
       # Create a temporary file in MAFIA_BIN so we can do an atomic copy/move dance.
+      mkdir -p $MAFIA_BIN
       MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
 
       clean_up () {
@@ -62,7 +87,6 @@ exec_mafia () {
 
         bin/bootstrap ) || exit $?
 
-      mkdir -p $(dirname $MAFIA_PATH)
       cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
       chmod +x "$MAFIA_PATH_TEMP"
       mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
@@ -83,7 +107,7 @@ else
 fi
 
 case "$MODE" in
-upgrade) shift; run_$MODE "$@" ;;
+upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: f4651778981b274c69026990a799d473e8d32871
+# Version: 7a89927a3be2e4d7541b04784a52caa80d8e6c7e

--- a/snooze.cabal
+++ b/snooze.cabal
@@ -47,6 +47,7 @@ library
 
                        Snooze.Balance
                        Snooze.Core
+                       Snooze.Data
                        Snooze.Json
                        Snooze.Text
                        Snooze.Url

--- a/src/Snooze/Data.hs
+++ b/src/Snooze/Data.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+module Snooze.Data (
+    Component (..)
+  , Query (..)
+  , Service (..)
+  , Registry (..)
+  , Entry (..)
+  , ContentType (..)
+  ) where
+
+
+import           Control.Retry (RetryPolicy)
+
+import           Data.ByteString (ByteString)
+import           Data.String (IsString)
+import           Data.Text (Text)
+import           Data.Map.Strict (Map)
+
+import           P
+
+import           Snooze.Balance.Data (UpdatableBalanceTable)
+
+newtype Component =
+  Component {
+      component :: Text
+    } deriving (Eq, Show, Ord, IsString)
+
+data Query =
+  Query {
+      queryKey :: Text
+    , queryValue :: Text
+    } deriving (Eq, Show)
+
+newtype Service =
+  Service {
+      serviceName :: Text
+    } deriving (Eq, Show, Ord)
+
+newtype ContentType =
+  ContentType {
+      contentType :: ByteString
+    } deriving (Eq, Show, Ord)
+
+data Entry =
+  Entry {
+      entryContentType :: ContentType
+    , entryBalanceTable :: UpdatableBalanceTable
+    , entryRetryPolicy :: RetryPolicy
+    }
+
+newtype Registry =
+  Registry {
+      mappings :: Map Service Entry
+    }


### PR DESCRIPTION
This is a nothing change, but putting it up as a heads up that I am going to start pushing through a series of improvements to snooze. They are basically of the form:
 - Convert to a unified snooze structure for maintaining the client registry rather than 1 snooze bag per service.
 - Add first-class support for snooze uri's so services can use them as location headers.
 - A neater api for constructing requests and handling responses.
 - First class support for passport style request-id threading.
 - Support for outbound request logging for internal services. 

This is basically a first cut at some of the extra types that will be needed to do the above.