### PR TITLE
Balance plain requests

### DIFF
--- a/snooze.cabal
+++ b/snooze.cabal
@@ -101,3 +101,5 @@ test-suite test-io
                      , ambiata-snooze
                      , text
                      , wai
+                     , data-default                    >= 0.5        && < 0.7
+

--- a/snooze.cabal
+++ b/snooze.cabal
@@ -82,24 +82,22 @@ test-suite test-io
   main-is:             test-io.hs
   ghc-options:         -Wall -threaded -O2
   hs-source-dirs:      test
-  build-depends:       aeson
-                     , base
-                     , bytestring
-                     , containers
-                     , http-client
-                     , http-types
+  build-depends:       base
+                     , QuickCheck
                      , aeson
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
-                     , network
                      , ambiata-p
-                     , scotty                          >= 0.8        && < 0.12
-                     , QuickCheck
+                     , ambiata-snooze
+                     , bytestring
+                     , containers
+                     , data-default                    >= 0.5        && < 0.7
+                     , http-client
+                     , http-types
+                     , network
                      , quickcheck-instances
                      , random
                      , retry
-                     , ambiata-snooze
+                     , scotty                          >= 0.8        && < 0.12
                      , text
                      , wai
-                     , data-default                    >= 0.5        && < 0.7
-

--- a/src/Snooze/Balance/Core.hs
+++ b/src/Snooze/Balance/Core.hs
@@ -5,6 +5,7 @@
 module Snooze.Balance.Core (
     module Control.Retry
   , balanceRequest
+  , balanceRequest'
   , balance
   , tick
   , randomRoundRobin'
@@ -17,6 +18,8 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Random
 import           Control.Monad.State
 import           Control.Retry
+
+import qualified Data.Text.Encoding as T
 
 import           Network.HTTP.Client
 
@@ -35,6 +38,13 @@ import           X.Control.Monad.Trans.Either
 balanceRequest :: BalanceEntry -> Request
 balanceRequest (BalanceEntry (Host h) (Port p)) =
   requestCreate h p
+
+balanceRequest' :: BalanceEntry -> Request -> Request
+balanceRequest' (BalanceEntry (Host h) (Port p)) r =
+  r {
+    host = T.encodeUtf8 h
+  , port = p
+  }
 
 balance :: (Applicative m, MonadIO m) =>
               Duration


### PR DESCRIPTION
`balancedRequest` takes a `Request -> Request` which it applies to `def :: Request` (after updating the host and port) to get the final version. I ran into problems when integrating request-signing into clients using `snooze` - not all constructable `http-client` `Request`s are valid HTTP requests/able to be converted to canonical form, so there is no pure `Request -> Request` I can make which does the right thing. This adds `balancedRequestReq` which takes a `Request` and sets the host and port directly.

! @charleso 